### PR TITLE
Replace deprecated pc.onaddstream callback with pc.ontrack

### DIFF
--- a/web/main.js
+++ b/web/main.js
@@ -61,7 +61,7 @@ let createPeerConnection = () => {
   try {
     pc = new RTCPeerConnection(PC_CONFIG);
     pc.onicecandidate = onIceCandidate;
-    pc.onaddstream = onAddStream;
+    pc.ontrack = onTrack;
     pc.addStream(localStream);
     console.log('PeerConnection created');
   } catch (error) {
@@ -101,9 +101,9 @@ let onIceCandidate = (event) => {
   }
 };
 
-let onAddStream = (event) => {
-  console.log('Add stream');
-  remoteStreamElement.srcObject = event.stream;
+let onTrack = (event) => {
+  console.log('Add track');
+  remoteStreamElement.srcObject = event.streams[0];
 };
 
 let handleSignalingData = (data) => {


### PR DESCRIPTION
This **webrtc-working-example** project helped me learn how to use **webrtc**.  While playing with it I discovered two issues that seemed worth fixing, hence this PR:

**(1)** `RTCPeerConnection.onaddstream` callback has been deprecated; we are to use `RTCPeerConnection.ontrack` instead
**(2)** The `socket.io.js` was old and would not work with a fresh **python-socketio** package, so I updated it to **v4.2.0**